### PR TITLE
added small tweak so that input elements which have localized titles don...

### DIFF
--- a/src/jquery.localize.coffee
+++ b/src/jquery.localize.coffee
@@ -84,6 +84,8 @@ $.localize = (pkg, options = {}) ->
   localizeInputElement = (elem, key, value) ->
     if elem.is("[placeholder]")
       elem.attr("placeholder", value)
+    else if value.value
+      elem.val(value.value)
     else
       elem.val(value)
 


### PR DESCRIPTION
This builds on the previous addition that allowed title localization on any element.  For input elements, the localizeInputElement didn't consider that the value might be an object with value/title keys.  I added a test for this.
