### PR TITLE
Handle input elements with a title set

### DIFF
--- a/build/jquery.localize.js
+++ b/build/jquery.localize.js
@@ -107,10 +107,15 @@
       }
     };
     localizeInputElement = function(elem, key, value) {
+      var val;
+      val = value;
+      if (value.value) {
+        val = value.value;
+      }
       if (elem.is("[placeholder]")) {
-        return elem.attr("placeholder", value);
+        return elem.attr("placeholder", val);
       } else {
-        return elem.val(value);
+        return elem.val(val);
       }
     };
     localizeForSpecialKeys = function(elem, value) {

--- a/src/jquery.localize.coffee
+++ b/src/jquery.localize.coffee
@@ -82,12 +82,16 @@ $.localize = (pkg, options = {}) ->
     localizeForSpecialKeys(elem, value) if $.isPlainObject(value)
 
   localizeInputElement = (elem, key, value) ->
+    val = value
+    # if the user wants to set the title of an input element via
+    # keyword.title, we need to specially handle the keyword.value
+    if value.value
+      val = value.value
+
     if elem.is("[placeholder]")
-      elem.attr("placeholder", value)
-    else if value.value
-      elem.val(value.value)
+      elem.attr("placeholder", val)
     else
-      elem.val(value)
+      elem.val(val)
 
   localizeForSpecialKeys = (elem, value) ->
     setAttrFromValueForKey(elem, "title", value)

--- a/test/lang/test-ja.json
+++ b/test/lang/test-ja.json
@@ -1,7 +1,11 @@
 {
   "test": {
     "nested": "nested success",
-    "input": "input success",
+    "normalinput": "normalinput success",
+    "titledinput": {
+        "value": "titledinput value success",
+        "title": "titledinput title success"
+    },
     "optgroup": "optgroup success",
     "option": "option success",
     "ruby_image": {

--- a/test/localize_test.coffee
+++ b/test/localize_test.coffee
@@ -43,14 +43,29 @@ test "basic tag text substitution for special title key", ->
   equals t.attr("title"), "with_title title success"
 
 test "input tag value substitution", ->
-  t = localizableTagWithRel("input", "test.input", val: "input fail")
+  t = localizableTagWithRel("input", "test.normalinput", val: "normalinput fail")
   t.localize("test", @testOpts)
-  equals t.val(), "input success"
+  equals t.val(), "normalinput success"
 
 test "input tag placeholder substitution", ->
-  t = localizableTagWithRel("input", "test.input", placeholder: "placeholder fail")
+  t = localizableTagWithRel("input", "test.normalinput", placeholder: "placeholder fail")
   t.localize("test", @testOpts)
-  equals t.attr("placeholder"), "input success"
+  equals t.attr("placeholder"), "normalinput success"
+
+test "titled input tag value substitution", ->
+  t = localizableTagWithRel("input", "test.titledinput", val: "titledinput fail")
+  t.localize("test", @testOpts)
+  equals t.val(), "titledinput value success"
+
+test "titled input tag title substitution", ->
+  t = localizableTagWithRel("input", "test.titledinput", val: "titledinput fail")
+  t.localize("test", @testOpts)
+  equals t.attr("title"), "titledinput title success"
+
+test "titled input tag placeholder substitution", ->
+  t = localizableTagWithRel("input", "test.titledinput", placeholder: "placeholder fail")
+  t.localize("test", @testOpts)
+  equals t.attr("placeholder"), "titledinput value success"
 
 test "image tag src, alt, and title substitution", ->
   t = localizableTagWithRel("img", "test.ruby_image", src: "ruby_square.gif", alt: "a square ruby", title: "A Square Ruby")


### PR DESCRIPTION
Take two:

I tried to set the title attribute on an input element, and the value of the input element was set to '[Object object]' .  Added a change to allow for keyword.value when using keyword.title on input elements to prevent this.

Also added qunit tests to test the 'classic' behavior ("keyword": "insert this value") as well as the new behavior ('keyword": { "value": "insert this value", "title": "insert this title"}').
