### PR TITLE
Update jquery.localize.coffee

### DIFF
--- a/src/jquery.localize.coffee
+++ b/src/jquery.localize.coffee
@@ -49,7 +49,9 @@ do ($ = jQuery) ->
         notifyDelegateLanguageLoaded(intermediateLangData)
         loadLanguage(pkg, lang, level + 1)
       errorFunc = ->
-        if options.fallback && options.fallback != lang
+        if level <= 2
+          loadLanguage(pkg, lang, level + 1)
+        else if options.fallback && options.fallback != lang
           loadLanguage(pkg, options.fallback)
       ajaxOptions =
         url: file


### PR DESCRIPTION
Add a checking so that if language is `en-US` and `en.json` doesn't exist, it can still find `en-US.json`