### PR TITLE
Add metadata and main field to package json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
+sudo: false
 language: node_js
 node_js:
-  - "0.11"
+  - "4"
 before_script:
   - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "node": ">= 0.8.0"
   },
   "scripts": {
+    "prepublish": "grunt",
     "test": "grunt test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-qunit": "~0.2.0",
-    "grunt-contrib-uglify": "~0.2.0",
-    "grunt-contrib-clean": "~0.4.0",
     "grunt": "~0.4.2",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-coffee": "~0.10.0",
-    "grunt-contrib-connect": "~0.6.0"
+    "grunt-contrib-connect": "~0.6.0",
+    "grunt-contrib-qunit": "~0.2.0",
+    "grunt-contrib-uglify": "~0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,19 @@
 {
   "name": "jquery-localize",
-  "version": "0.0.0-ignored",
+  "description": "A jQuery plugin that makes it easy to i18n your static web site.",
+  "version": "0.1.0",
+  "homepage": "https://github.com/coderifous/jquery-localize",
+  "license": "MIT",
+  "main": "dist/jquery.localize.js",
+  "author": {
+    "name": "coderifous",
+    "email": "jim@thegarvin.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coderifous/jquery-localize.git"
+  },
+  "bugs": "https://github.com/coderifous/jquery-localize/issues",
   "engines": {
     "node": ">= 0.8.0"
   },


### PR DESCRIPTION
Since [the jQuery plugin registry is no longer writable, and instead recommends publishing packages to npm](https://plugins.jquery.com/), this adds all of the metadata from the `localize.jquery.json` file to the `package.json` including the "main" field pointing to the unminified build. 

`jquery` was not added as a dependency as it is not explicitly `require`d.

Would appreciate an `npm publish` when you're ready :smile: 